### PR TITLE
feat: improve logging for json parsing and tools

### DIFF
--- a/app/[...site]/route.ts
+++ b/app/[...site]/route.ts
@@ -24,6 +24,7 @@ const handler = async (
           query: z.string().describe("Search query string (supports boolean operators like AND, OR)"),
         },
         async ({ query }) => {
+          console.log('Tool "search" invoked with params:', { query });
           try {
             // Perform the search (index loading is now handled automatically)
             const result = await searchClient.search(query, baseUrl);
@@ -70,6 +71,7 @@ const handler = async (
           id: z.string().describe("Document ID from search results")
         },
         async ({ id }) => {
+          console.log('Tool "fetch" invoked with params:', { id });
           try {
             const fetchResult = await searchClient.fetchDocumentContent(id, baseUrl);
 


### PR DESCRIPTION
## Summary
- add helper to log the first 500 characters of JSON strings when parsing fails
- log search and fetch tool invocations with parameters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc833c07388325a330bfb9a057f68b