### PR TITLE
docs: add security considerations for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ The server dynamically loads the WebHelp search index for a requested site and e
 4. Push to a GitHub repository and import it into [Vercel](https://vercel.com/). The default settings are sufficient—no extra environment variables are required.
 5. Access your server at `https://<your-vercel-domain>/<site>`.
 
+## Security
+
+Hosting this server yourself exposes you to several risks that should be
+considered before making it publicly available:
+
+- **Server-side request forgery (SSRF)** – the endpoint fetches HTML from any
+  URL specified in the request path. An attacker could leverage your instance
+  to reach internal or otherwise restricted resources.
+- **Resource exhaustion** – large or repeated queries may consume significant
+  CPU, memory or bandwidth and degrade the host system.
+- **Untrusted content** – the server transforms external HTML into Markdown
+  and returns it to the requester. Malicious markup could be relayed to clients
+  if additional sanitization is not performed.
+
+Apply network controls, rate limiting and request validation when running your
+own deployment.
+
 ## License
 
 Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document key security risks for self-hosters, including SSRF, resource exhaustion, and handling untrusted content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d64e3748325b073589cf95464e1