### PR TITLE
Add WebHelp search client integration test

### DIFF
--- a/lib/downloadFile.ts
+++ b/lib/downloadFile.ts
@@ -1,21 +1,39 @@
 import { IncomingMessage } from "http";
 import * as https from 'https';
 import * as http from 'http';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { HttpProxyAgent } from 'http-proxy-agent';
 
 
 export async function downloadFile(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const client = url.startsWith('https://') ? https : http;
-    
-    client.get(url, (response: IncomingMessage) => {
-      if (response.statusCode !== 200) {
-        reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
-        return;
-      }
+    const isHttps = url.startsWith('https://');
+    const client = isHttps ? https : http;
 
-      let data = '';
-      response.on('data', chunk => data += chunk);
-      response.on('end', () => resolve(data));
-    }).on('error', reject);
+    const proxyUrl =
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy;
+
+    const options: any = {};
+    if (proxyUrl) {
+      options.agent = isHttps
+        ? new HttpsProxyAgent(proxyUrl)
+        : new HttpProxyAgent(proxyUrl);
+    }
+
+    client
+      .get(url, options, (response: IncomingMessage) => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
+          return;
+        }
+
+        let data = '';
+        response.on('data', chunk => (data += chunk));
+        response.on('end', () => resolve(data));
+      })
+      .on('error', reject);
   });
 }

--- a/lib/webhelp-search-client.test.ts
+++ b/lib/webhelp-search-client.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { WebHelpSearchClient } from './webhelp-search-client';
+
+const WEBHELP_URL = 'https://www.oxygenxml.com/doc/versions/27.1/ug-editor/';
+
+test('search for wsdl and fetch first result', async () => {
+  const client = new WebHelpSearchClient();
+  const searchResult = await client.search('wsdl', WEBHELP_URL);
+
+  assert.ok(!searchResult.error, searchResult.error);
+  assert.ok(searchResult.resultCount > 0, 'expected at least one search result');
+
+  const first = searchResult.results[0];
+  assert.ok(first, 'no first result returned');
+
+  const doc = await client.fetchDocumentContent(first.path, WEBHELP_URL);
+  const snippet =
+    'You can use Oxygen XML Editor to generate detailed documentation for the components ' +
+    'of a WSDL document in HTML format.';
+  assert.ok(
+    doc.text.includes(snippet),
+    `document should include snippet: ${snippet}`
+  );
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "tsx --test lib/webhelp-search-client.test.ts"
   },
   "keywords": [
     "webhelp",


### PR DESCRIPTION
## Summary
- support HTTP/HTTPS proxy when downloading files
- add integration test covering WebHelpSearchClient search and fetch flow with a full-page snippet assertion
- expose `npm test` script to run the new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd215d1b848325a46659a7f468af44