### PR TITLE
feat: add URL pack encoder

### DIFF
--- a/lib/url-pack.test.ts
+++ b/lib/url-pack.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { encodeUrls, decodeUrls } from './url-pack';
+
+test('round trip works and input is sorted', () => {
+  const input = [
+    'https://www.example.com/products/books/non-fiction/sapiens',
+    'https://www.example.com/products/electronics/laptops/dell-xps-15',
+    'https://www.example.com/about-us/company-history',
+  ];
+
+  const encoded = encodeUrls(input);
+  const decoded = decodeUrls(encoded);
+
+  const expected = [...input].sort();
+  assert.deepEqual(decoded, expected);
+});
+
+test('empty input round trips to empty output', () => {
+  assert.equal(encodeUrls([]), '');
+  assert.deepEqual(decodeUrls(''), []);
+});
+
+test('highly similar prefixes yield strong compression', () => {
+  const urls = [
+    'https://www.example.com/products/electronics/laptops/macbook-pro-16',
+    'https://www.example.com/products/electronics/laptops/dell-xps-15',
+    'https://www.example.com/products/electronics/smartphones/iphone-15-pro',
+    'https://www.example.com/products/electronics/smartphones/google-pixel-8',
+    'https://www.example.com/products/books/fiction/the-great-gatsby',
+    'https://www.example.com/products/books/non-fiction/sapiens',
+    'https://www.example.com/about-us/company-history',
+    'https://www.example.com/about-us/careers',
+  ];
+
+  const encoded = encodeUrls(urls);
+  const decoded = decodeUrls(encoded);
+  assert.deepEqual(decoded, [...urls].sort());
+
+  const original = urls.join('\n');
+  const ratio = encoded.length / original.length;
+  assert.ok(
+    ratio < 0.6,
+    `expected ratio < 0.6, got ${ratio}`,
+  );
+});
+
+test('mixed and dissimilar URLs compress only slightly', () => {
+  const urls = [
+    'https://google.com/search?q=url+compression',
+    'https://github.com/google/brotli',
+    'https://developer.mozilla.org/en-US/docs/Web/JavaScript',
+    'https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Welch',
+    'https://news.ycombinator.com/',
+    'https://www.reddit.com/r/programming/',
+  ];
+
+  const encoded = encodeUrls(urls);
+  const decoded = decodeUrls(encoded);
+  assert.deepEqual(decoded, [...urls].sort());
+
+  const ratio = encoded.length / urls.join('\n').length;
+  assert.ok(
+    ratio > 0.8 && ratio < 1,
+    `expected 0.8 < ratio < 1, got ${ratio}`,
+  );
+});
+
+test('very long but similar URLs compress strongly', () => {
+  const urls = [
+    'https://api.cloudservice.com/v1/users/12345/projects/project-alpha/files/main/src/app/components/user-profile.js?token=xyz&session=abc',
+    'https://api.cloudservice.com/v1/users/12345/projects/project-alpha/files/main/src/app/components/settings.js?token=xyz&session=abc',
+    'https://api.cloudservice.com/v1/users/12345/projects/project-alpha/files/main/src/app/services/auth.js?token=xyz&session=abc',
+    'https://api.cloudservice.com/v1/users/12345/projects/project-beta/files/main/src/app/dashboard.js?token=xyz&session=abc',
+  ];
+
+  const encoded = encodeUrls(urls);
+  const decoded = decodeUrls(encoded);
+  assert.deepEqual(decoded, [...urls].sort());
+
+  const ratio = encoded.length / urls.join('\n').length;
+  assert.ok(
+    ratio < 0.5,
+    `expected ratio < 0.5, got ${ratio}`,
+  );
+});
+
+test('a single URL typically expands slightly', () => {
+  const urls = [
+    'https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers',
+  ];
+  const encoded = encodeUrls(urls);
+  const decoded = decodeUrls(encoded);
+  assert.deepEqual(decoded, [...urls]);
+
+  const ratio = encoded.length / urls[0].length;
+  assert.ok(
+    ratio > 1,
+    `expected ratio > 1, got ${ratio}`,
+  );
+});
+

--- a/lib/url-pack.ts
+++ b/lib/url-pack.ts
@@ -1,0 +1,76 @@
+import { deflateSync, inflateSync } from 'zlib';
+
+/**
+ * Encode an array of URLs into a compressed, URL-safe string.
+ * Steps:
+ * 1. Sort URLs alphabetically to maximise prefix similarity.
+ * 2. Prefix-diff each URL against the previous one and join with newlines.
+ * 3. Deflate the diff string using zlib.
+ * 4. Base64url encode the binary result.
+ */
+export function encodeUrls(urls: string[]): string {
+  if (!urls || urls.length === 0) return '';
+
+  const sorted = [...urls].sort();
+  const diffs: string[] = [];
+  let last = '';
+
+  for (const url of sorted) {
+    if (!last) {
+      diffs.push(url);
+    } else {
+      let i = 0;
+      const minLen = Math.min(url.length, last.length);
+      while (i < minLen && url[i] === last[i]) i++;
+      const suffix = url.slice(i);
+      diffs.push(`${i}|${suffix}`);
+    }
+    last = url;
+  }
+
+  const joined = diffs.join('\n');
+  const compressed = deflateSync(joined);
+  return base64urlEncode(compressed);
+}
+
+/** Decode a string produced by {@link encodeUrls}. */
+export function decodeUrls(encoded: string): string[] {
+  if (!encoded) return [];
+  const decoded = base64urlDecode(encoded);
+  const joined = inflateSync(decoded).toString();
+  const diffs = joined.split('\n');
+
+  const urls: string[] = [];
+  let last = '';
+  for (const diff of diffs) {
+    const sepIndex = diff.indexOf('|');
+    if (sepIndex > -1) {
+      const prefixLen = parseInt(diff.slice(0, sepIndex), 10);
+      if (!isNaN(prefixLen)) {
+        const prefix = last.slice(0, prefixLen);
+        const url = prefix + diff.slice(sepIndex + 1);
+        urls.push(url);
+        last = url;
+        continue;
+      }
+    }
+    urls.push(diff);
+    last = diff;
+  }
+  return urls;
+}
+
+function base64urlEncode(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function base64urlDecode(str: string): Buffer {
+  let b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4;
+  if (pad) b64 += '='.repeat(4 - pad);
+  return Buffer.from(b64, 'base64');
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "tsx --test lib/webhelp-search-client.test.ts"
+    "test": "tsx --test lib/url-pack.test.ts lib/webhelp-search-client.test.ts"
   },
   "keywords": [
     "webhelp",


### PR DESCRIPTION
## Summary
- implement URL-Pack algorithm to compress and encode sets of URLs
- add round-trip tests for encoding/decoding
- expand tests with multiple scenarios and compression ratio checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd50ff46cc83259491128a2e9441f1