### PR TITLE
Add end-to-end MCP server test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "tsx --test lib/webhelp-search-client.test.ts"
+    "test": "tsx --test lib/*.test.ts"
   },
   "keywords": [
     "webhelp",


### PR DESCRIPTION
## Summary
- add end-to-end test that spins up the Next.js server, runs the `search` and `fetch` tools, and verifies content
- run tests with a glob pattern to catch all test files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd509390dc83258e46b3fb724bf3c6