### PR TITLE
feat: support multiple WebHelp search indexes

### DIFF
--- a/app/[...site]/route.ts
+++ b/app/[...site]/route.ts
@@ -44,8 +44,8 @@ const handler = async (
             const topResults = result.results.slice(0, maxResultsToUse);
             let results = topResults.map((doc: any) => ({
                 title: doc.title,
-                id: doc.path,
-                url: `${baseUrl}${doc.path}`
+                id: doc.id,
+                url: doc.url
               }));
             return {
               content: [{
@@ -73,7 +73,7 @@ const handler = async (
         async ({ id }) => {
           console.log('Tool "fetch" invoked with params:', { id });
           try {
-            const fetchResult = await searchClient.fetchDocumentContent(id, baseUrl);
+            const fetchResult = await searchClient.fetchDocumentContent(id);
 
             return {
               content: [{

--- a/lib/webhelp-search-client.test.ts
+++ b/lib/webhelp-search-client.test.ts
@@ -3,18 +3,21 @@ import assert from 'node:assert/strict';
 import { WebHelpSearchClient } from './webhelp-search-client';
 
 const WEBHELP_URL = 'https://www.oxygenxml.com/doc/versions/27.1/ug-editor/';
+const WEBHELP_URL2 = 'https://www.oxygenxml.com/doc/versions/27.1/ug-author/';
 
 test('search for wsdl and fetch first result', async () => {
   const client = new WebHelpSearchClient();
   const searchResult = await client.search('wsdl', WEBHELP_URL);
 
   assert.ok(!searchResult.error, searchResult.error);
-  assert.ok(searchResult.resultCount > 0, 'expected at least one search result');
+  assert.ok(searchResult.results.length > 0, 'expected at least one search result');
 
   const first = searchResult.results[0];
   assert.ok(first, 'no first result returned');
 
-  const doc = await client.fetchDocumentContent(first.path, WEBHELP_URL);
+  assert.ok(first.url.startsWith(WEBHELP_URL));
+
+  const doc = await client.fetchDocumentContent(first.id);
   const snippet =
     'You can use Oxygen XML Editor to generate detailed documentation for the components ' +
     'of a WSDL document in HTML format.';
@@ -22,4 +25,14 @@ test('search for wsdl and fetch first result', async () => {
     doc.text.includes(snippet),
     `document should include snippet: ${snippet}`
   );
+});
+
+test('search across multiple indexes', async () => {
+  const client = new WebHelpSearchClient();
+  const result = await client.search('XML', [WEBHELP_URL, WEBHELP_URL2]);
+
+  assert.ok(result.results.length > 0, 'expected search results');
+  const hasEditor = result.results.some(r => r.url.startsWith(WEBHELP_URL));
+  const hasAuthor = result.results.some(r => r.url.startsWith(WEBHELP_URL2));
+  assert.ok(hasEditor && hasAuthor, 'results should include both base URLs');
 });


### PR DESCRIPTION
## Summary
- streamlines multi-index search by sequentially loading each index and merging results by score
- trims search result shape to fields used by the MCP server and builds full document URLs from encoded IDs
- adds helper to resolve document URLs while dropping sandboxed search execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd69c530848325a1b6c62108887216