### PR TITLE
refactor: isolate index loader context

### DIFF
--- a/lib/webhelp-search-client.ts
+++ b/lib/webhelp-search-client.ts
@@ -55,16 +55,9 @@ export class WebHelpSearchClient {
         };
       }
 
-      if (!(global as any).performSearch) {
-        return {
-          error: 'Search engine not loaded properly - performSearch function not found',
-          results: []
-        };
-      }
-
       try {
         let result: any = null;
-        (global as any).performSearch(query, function(r: any) {
+        this.indexLoader.performSearch(query, function(r: any) {
           result = r;
         });
         const idx = this.baseUrls.indexOf(url);


### PR DESCRIPTION
## Summary
- refactor WebHelpIndexLoader to use an isolated search context
- update WebHelpSearchClient to invoke loader's performSearch instead of global

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7db8e6d08325ae09d2afc3d18656