### PR TITLE
feat: add federated search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { encodeUrls } from '../lib/url-pack';
 
 export default function HomePage() {
   const [webhelpUrls, setWebhelpUrls] = useState<string[]>([
@@ -28,21 +29,20 @@ export default function HomePage() {
       return;
     }
     try {
-      const mcp = trimmed
-        .map((u) => {
-          const url = new URL(u);
-          const pathWithoutProtocol = url.hostname + url.pathname;
-          return `${baseUrl.replace(/\/$/, '')}/${pathWithoutProtocol}`;
-        })
-        .join('\n');
-      setMcpUrls(mcp);
+      if (trimmed.length === 1) {
+        const url = new URL(trimmed[0]);
+        const pathWithoutProtocol = url.hostname + url.pathname;
+        setMcpUrls(`${baseUrl.replace(/\/$/, '')}/${pathWithoutProtocol}`);
+      } else {
+        const encoded = encodeUrls(trimmed);
+        setMcpUrls(`${baseUrl.replace(/\/$/, '')}/federated/${encoded}`);
+      }
     } catch {
       setMcpUrls('Please enter a valid URL');
     }
   }
 
   const addUrlField = () => {
-    alert('Work in progress');
     setWebhelpUrls([...webhelpUrls, '']);
   };
   const updateUrl = (index: number, value: string) => {

--- a/lib/mcp-server.e2e.test.ts
+++ b/lib/mcp-server.e2e.test.ts
@@ -85,6 +85,21 @@ test('mcp server federated search', async () => {
   const hasAuthor = searchResults.some((r: any) => r.url.startsWith(WEBHELP_URL2));
   assert.ok(hasEditor && hasAuthor, 'results should include both base URLs');
 
+  const first = searchResults[0];
+  assert.ok(first && first.id, 'first result should have an id');
+
+  const fetchResp = await client.callTool({ name: 'fetch', arguments: { id: first.id } });
+  assert.ok(fetchResp.content && fetchResp.content.length > 0, 'fetch returned content');
+  const doc = JSON.parse(fetchResp.content[0].text);
+  assert.ok(
+    doc.url.startsWith(WEBHELP_URL) || doc.url.startsWith(WEBHELP_URL2),
+    'fetched doc URL should come from one of the base URLs'
+  );
+  assert.ok(
+    doc.text.toLowerCase().includes('xml'),
+    'fetched document should include the search term'
+  );
+
   await client.close();
   await stop();
 });

--- a/lib/mcp-server.e2e.test.ts
+++ b/lib/mcp-server.e2e.test.ts
@@ -4,8 +4,11 @@ import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import { Client } from '@modelcontextprotocol/sdk/client';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp';
+import { encodeUrls } from './url-pack';
 
 const WEBHELP_ENDPOINT = 'www.oxygenxml.com/doc/versions/27.1/ug-editor';
+const WEBHELP_URL = 'https://www.oxygenxml.com/doc/versions/27.1/ug-editor/';
+const WEBHELP_URL2 = 'https://www.oxygenxml.com/doc/versions/27.1/ug-author/';
 
 async function startNextServer(): Promise<{ port: number; stop: () => Promise<void> }> {
   const proc = spawn(process.execPath, ['node_modules/next/dist/bin/next', 'dev', '-p', '0'], {
@@ -58,6 +61,29 @@ test('mcp server search and fetch tools', async () => {
     'You can use Oxygen XML Editor to generate detailed documentation for the components ' +
     'of a WSDL document in HTML format.';
   assert.ok(doc.text.includes(snippet), `document should include snippet: ${snippet}`);
+
+  await client.close();
+  await stop();
+});
+
+test('mcp server federated search', async () => {
+  const { port, stop } = await startNextServer();
+
+  const encoded = encodeUrls([WEBHELP_URL, WEBHELP_URL2]);
+  const transport = new StreamableHTTPClientTransport(
+    `http://localhost:${port}/federated/${encoded}`
+  );
+  const client = new Client({ name: 'e2e-test-client', version: '1.0.0' });
+  await client.connect(transport);
+
+  const searchResp = await client.callTool({ name: 'search', arguments: { query: 'XML' } });
+  assert.ok(searchResp.content && searchResp.content.length > 0, 'search returned content');
+  const searchResults = JSON.parse(searchResp.content[0].text);
+  assert.ok(searchResults.length > 0, 'expected search results');
+
+  const hasEditor = searchResults.some((r: any) => r.url.startsWith(WEBHELP_URL));
+  const hasAuthor = searchResults.some((r: any) => r.url.startsWith(WEBHELP_URL2));
+  assert.ok(hasEditor && hasAuthor, 'results should include both base URLs');
 
   await client.close();
   await stop();


### PR DESCRIPTION
## Summary
- add helper to decode federated route into multiple WebHelp URLs
- allow search tool to query across decoded URLs
- generate federated endpoints on the homepage when multiple docs are entered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd7e647a188325b4f486260f4c2c1e