### PR TITLE
fix: preserve hero animation final state

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,8 +18,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               animation: {
                 'float': 'float 6s ease-in-out infinite',
                 'glow': 'glow 2s ease-in-out infinite alternate',
-                'slide-up': 'slideUp 0.8s ease-out',
-                'fade-in': 'fadeIn 1s ease-out'
+                'slide-up': 'slideUp 0.8s ease-out forwards',
+                'fade-in': 'fadeIn 1s ease-out forwards'
               },
               keyframes: {
                 float: {


### PR DESCRIPTION
## Summary
- ensure slide-up and fade-in animations retain final state for hero content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beb400f9908325876cb5315ff02b9c