### PR TITLE
Prevent fade-in flicker by guarding class additions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,6 +55,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             backdrop-filter: blur(10px);
             background: rgba(255, 255, 255, 0.1);
             border: 1px solid rgba(255, 255, 255, 0.2);
+            opacity: 0;
+        }
+        .glass-effect.animate-fade-in {
+            opacity: 1;
         }
         .code-block {
             background: linear-gradient(135deg, #1e293b 0%, #334155 100%);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,7 +69,10 @@ export default function HomePage() {
       elements.forEach((element) => {
         const elementTop = element.getBoundingClientRect().top;
         const elementVisible = 150;
-        if (elementTop < window.innerHeight - elementVisible) {
+        if (
+          elementTop < window.innerHeight - elementVisible &&
+          !element.classList.contains('animate-fade-in')
+        ) {
           element.classList.add('animate-fade-in');
         }
       });


### PR DESCRIPTION
## Summary
- Avoid re-adding `animate-fade-in` class during scroll to stop animation restarts
- Ensure `.glass-effect` elements start hidden and become visible with `animate-fade-in`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68befac0eccc8325b8008c1fc8c7dc74