### PR TITLE
refactor search client base URL handling

### DIFF
--- a/lib/webhelp-search-client.test.ts
+++ b/lib/webhelp-search-client.test.ts
@@ -6,8 +6,8 @@ const WEBHELP_URL = 'https://www.oxygenxml.com/doc/versions/27.1/ug-editor/';
 const WEBHELP_URL2 = 'https://www.oxygenxml.com/doc/versions/27.1/ug-author/';
 
 test('search for wsdl and fetch first result', async () => {
-  const client = new WebHelpSearchClient();
-  const searchResult = await client.search('wsdl', WEBHELP_URL);
+  const client = new WebHelpSearchClient(WEBHELP_URL);
+  const searchResult = await client.search('wsdl');
 
   assert.ok(!searchResult.error, searchResult.error);
   assert.ok(searchResult.results.length > 0, 'expected at least one search result');
@@ -25,8 +25,8 @@ test('search for wsdl and fetch first result', async () => {
 });
 
 test('search across multiple indexes', async () => {
-  const client = new WebHelpSearchClient();
-  const result = await client.search('XML', [WEBHELP_URL, WEBHELP_URL2]);
+  const client = new WebHelpSearchClient([WEBHELP_URL, WEBHELP_URL2]);
+  const result = await client.search('XML');
 
   assert.ok(result.results.length > 0, 'expected search results');
   const hasEditor = result.results.some(r => r.url.startsWith(WEBHELP_URL));
@@ -35,9 +35,13 @@ test('search across multiple indexes', async () => {
 });
 
 test('semantic search returns results', async () => {
-  const client = new WebHelpSearchClient();
+  const client = new WebHelpSearchClient(WEBHELP_URL);
   const result = await client.semanticSearch('wsdl', WEBHELP_URL);
   assert.ok(result.results.length > 0, 'expected semantic search results');
   const first = result.results[0];
   assert.ok(first.url.startsWith(WEBHELP_URL));
+});
+
+test('constructor requires base URLs', () => {
+  assert.throws(() => new WebHelpSearchClient(), /No base URL provided/);
 });


### PR DESCRIPTION
## Summary
- accept base URLs in `WebHelpSearchClient` constructor instead of search/fetch calls
- let `search` try semantic search for a single base URL and fall back to index search
- simplify Next.js route to use new client API without duplicating semantic logic
- enforce base URL requirement at construction time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf275cc00883259d95f4bd73d3728e