### PR TITLE
Skip loading unsupported metadata files

### DIFF
--- a/lib/webhelp-index-loader.ts
+++ b/lib/webhelp-index-loader.ts
@@ -2,8 +2,6 @@ import { downloadFile } from './downloadFile';
 
 interface MetadataFiles {
   stopwords: string;
-  linkToParent: string;
-  keywords: string;
   htmlFileInfoList: string;
 }
 
@@ -68,9 +66,7 @@ export class WebHelpIndexLoader {
   async downloadMetadataFiles(searchUrl: string): Promise<MetadataFiles> {
     const metaFiles: MetadataFile[] = [
       { name: 'htmlFileInfoList.js', var: 'htmlFileInfoList' },
-      { name: 'stopwords.js', var: 'stopwords' },
-      { name: 'link-to-parent.js', var: 'linkToParent' },
-      { name: 'keywords.js', var: 'keywords' }
+      { name: 'stopwords.js', var: 'stopwords' }
     ];
 
     const loadedFiles: any = {};
@@ -344,8 +340,6 @@ export class WebHelpIndexLoader {
 
       // Process metadata files into our context
       this.processStopwords(metadataFiles.stopwords);
-      this.processLinkToParent(metadataFiles.linkToParent);
-      this.processKeywords(metadataFiles.keywords);
       this.processFileInfoList(metadataFiles.htmlFileInfoList);
 
       // Process index files into our context


### PR DESCRIPTION
## Summary
- avoid downloading `link-to-parent.js` and `keywords.js` in the index loader
- only process stopwords and file info list metadata

## Testing
- `npm test`
- `npx tsx -e "import {WebHelpIndexLoader} from './lib/webhelp-index-loader.ts'; (async () => {const loader=new WebHelpIndexLoader(); await loader.loadIndex('https://www.oxygenxml.com/doc/versions/25.0/ug-editor/'); console.log('Index loaded');})();"`

------
https://chatgpt.com/codex/tasks/task_e_68bf2930d6c083259ad065399575b7d8